### PR TITLE
Add basic filtering functionality

### DIFF
--- a/backend/controllers/book.api.js
+++ b/backend/controllers/book.api.js
@@ -6,7 +6,7 @@ const config = require("./../helpers/config");
 module.exports = {
   getBooks: async function (req, res) {
     const options = await config.getOptions(req);
-    await Book.paginate({}, options, async function (err, books) {
+    await Book.paginate(options.filter, options, async function (err, books) {
       if (err) {
         return res.json({
           success: false,

--- a/backend/controllers/chapter.api.js
+++ b/backend/controllers/chapter.api.js
@@ -28,7 +28,7 @@ module.exports = {
   getChapters: async (req, res) => {
     const options = await config.getOptions(req);
 
-    await Chapter.paginate({}, {
+    await Chapter.paginate(options.filter, {
       ...options,
       select: {
         chapterName: 1,

--- a/backend/controllers/character.api.js
+++ b/backend/controllers/character.api.js
@@ -6,8 +6,8 @@ const mongoose = require("mongoose");
 
 module.exports = {
   getCharacters: async (req, res, next) => {
-    const options = await config.getOptions(req);
-    await Character.paginate({}, options, async function (err, characters) {
+    const options = await config.getOptions(req);        
+    await Character.paginate(options.filter, options, async function (err, characters) {
       if (err) {
         return res.status(500).send({
           success: false,

--- a/backend/controllers/movie.api.js
+++ b/backend/controllers/movie.api.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   getMovies: async (req, res, next) => {
     const options = await config.getOptions(req);
-    await Movie.paginate({}, options, async function (err, movies) {
+    await Movie.paginate(options.filter, options, async function (err, movies) {
       if (err) {
         return res.status(500).send({
           success: false,

--- a/backend/controllers/quote.api.js
+++ b/backend/controllers/quote.api.js
@@ -5,7 +5,7 @@ module.exports = {
   getQuotes: async (req, res) => {
     const options = await config.getOptions(req);
     await Quote.paginate(
-      {},
+      options.filter,
       {
         ...options,
         select: {

--- a/backend/helpers/config.js
+++ b/backend/helpers/config.js
@@ -1,11 +1,24 @@
+var mongooseQueryParser = require('mongoose-query-parser');
+
 module.exports = {
   getOptions: async function (req) {
-    let options = {};
+    let options = { filter: {} };
 
     const sort = req.query.sort;
     let limit = req.query.limit;
     let page = req.query.page;
     let offset = req.query.offset;
+
+    // Express does not offer a handy way to get the raw query strings
+    // so lets parse it and drop the leading `?` for the parser
+    const url = new URL(req.protocol + '://' + req.hostname + req.originalUrl);
+    const rawQueryParams = url.search.slice(1);
+
+    const parser = new mongooseQueryParser.MongooseQueryParser({
+      blacklist: ['offset', 'page', 'limit', 'sort']
+    });
+    const parsed = parser.parse(rawQueryParams);
+    options.filter = parsed.filter;
 
     if (sort) {
       const fields = sort.split(":");

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -519,6 +519,11 @@
       "resolved": "http://medapf-ci.iavgroup.local:80/mvn/api/npm/npm-remote/kareem/-/kareem-2.3.1.tgz",
       "integrity": "sha1-3vEtnJQQF/q/sA+HOvlenJnhvoc="
     },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "http://medapf-ci.iavgroup.local:80/mvn/api/npm/npm-remote/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -631,6 +636,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.0.tgz",
+      "integrity": "sha512-z6IJ5HXYiuxvFTI6eiQ9dm77uE0gyy1yXNApVHqTcnIKfY9tIwEjlzsZ6u1LQXvVgKeTnv9Xm7NDvJ7lso3MtA=="
+    },
     "mongodb": {
       "version": "3.5.9",
       "resolved": "http://medapf-ci.iavgroup.local:80/mvn/api/npm/npm-remote/mongodb/-/mongodb-3.5.9.tgz",
@@ -680,6 +690,15 @@
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.0.5.tgz",
           "integrity": "sha1-L/nQfJs+2ynW0oD+B1KDZefs05I="
         }
+      }
+    },
+    "mongoose-query-parser": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/mongoose-query-parser/-/mongoose-query-parser-1.1.7.tgz",
+      "integrity": "sha512-4uoiUDf/zD35L2zEo+t7zpU/9cW/9YtlqoYwInKX1yW9EZiaQ1MfqKhBEJUHf/yYTOLvrvSkCaA/eLYsH3UkCw==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "moment": "^2.27.0"
       }
     },
     "mpath": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.9.19",
     "mongoose-paginate": "^5.0.3",
+    "mongoose-query-parser": "^1.1.7",
     "nanoid": "^3.1.12",
     "node-fetch": "^2.6.0",
     "passport": "^0.4.1",


### PR DESCRIPTION
Hello 👋 I stumbled across this repo a bit ago and love it! I wanted to try to add some filtering functionality as that seemed to be a missing feature. Mostly I just hated parsing all the entries on the /character response to get character ids for quotes. So I followed your [contributing guidelines](https://github.com/gitfrosh/lotr-api/blob/release/CONTRIBUTING.md) and gave it a shot.

## Description

The changes on here are straightforward:
* Install [mongoose-query-parser](https://www.npmjs.com/package/mongoose-query-parser)  package to the backend
* Parse non-pagination params into a filterable structure for mongoose.

A client can pass any params related to the model schema to filter. Namely for strings we can do regex or exact match lookups like `/Gandalf/i` or `Human`.

```
# Using a delightful curl-like cli named httpie
http :3001/v2/character name=='/Gandalf/i' "Authorization: Bearer $TOKEN"  # Where is that wizard?
http :3001/v2/character name=='/foot/i' race=='Hobbit' limit==1 "Authorization: Bearer $TOKEN"  # First hobbit with foot in the name
http :3001/v2/character name=='/foot/i' race=='Hobbit' limit==2 sort==name:desc "Authorization: Bearer $TOKEN" # Sort it by alphabetically descending name now
```

## Design Issues

The filtering relies on the client to make the proper query, so parameters that do not match the model schemes are still processed and attempted to match, causing no results to be returned. Some APIs follow this paradigm and some don't but we can potentially change the config to blacklist these values or return errors on unmatched keys.
```
http :3001/v2/character foo=='/bar/i' "Authorization: Bearer $TOKEN"
```

Let me know your thought on this whenever you get a chance.