### PR TITLE
Add overflow-wrap break-word

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -79,6 +79,10 @@ p, li, ul, th, td, tr, em, a, b, input, label, button {
   }
 }
 
+td {
+  overflow-wrap: break-word !important;
+}
+
 h1 {
   color: var(--card-border-color);
   font-size: 40px !important;


### PR DESCRIPTION
Stops truncating endpoints in the docs
<img width="1440" alt="Screenshot 2021-06-02 at 09 59 30" src="https://user-images.githubusercontent.com/66833364/120445791-43c74200-c389-11eb-9d4f-8c9299b181b1.png">
Closes #38 