### PR TITLE
More consistent error codes and format

### DIFF
--- a/backend/controllers/auth.spec.js
+++ b/backend/controllers/auth.spec.js
@@ -6,6 +6,7 @@ const { HttpCode } = require('../helpers/constants');
 
 const userModel = require('../models/user.model');
 const authController = require('./auth');
+const errorHandler = require('../middleware/api.errors');
 
 const app = express();
 const router = express.Router();
@@ -14,6 +15,7 @@ router.route("/register").post(authController.register);
 
 app.use(express.json());
 app.use('/auth', router);
+app.use(errorHandler)
 
 const requestBody = { email: 'email@mail.com', password: 'P@$$1' };
 

--- a/backend/controllers/book.api.js
+++ b/backend/controllers/book.api.js
@@ -3,19 +3,17 @@ const Chapter = require('./../models/chapter.model');
 const mongoose = require('mongoose');
 const config = require('./../helpers/config');
 
-const { errorResponse } = require('../helpers/constants');
-
 module.exports = {
-  getBooks: async (req, res) => {
+  getBooks: async (req, res, next) => {
     const options = await config.getOptions(req);
     try {
       const books = await Book.paginate(options.filter, options);
       return res.json(books);
     } catch (err) {
-      return res.json(errorResponse);
+      return next(err);
     }
   },
-  getBook: async (req, res) => {
+  getBook: async (req, res, next) => {
     const options = await config.getOptions(req);
 
     try {
@@ -23,10 +21,10 @@ module.exports = {
       const book = await Book.paginate({ _id: id }, options);
       return res.json(book);
     } catch (err) {
-      return res.json(errorResponse);
+      return next(err);
     }
   },
-  getChaptersByBook: async (req, res) => {
+  getChaptersByBook: async (req, res, next) => {
     const options = await config.getOptions(req);
 
     try {
@@ -37,7 +35,7 @@ module.exports = {
       });
       return res.json(book);
     } catch (err) {
-      return res.json(errorResponse);
+      return next(err);
     }
   },
 };

--- a/backend/controllers/book.api.spec.js
+++ b/backend/controllers/book.api.spec.js
@@ -8,6 +8,7 @@ const chapterModel = require('../models/chapter.model');
 
 const bookController = require('./book.api');
 const bookModel = require('../models/book.model');
+const errorHandler = require('../middleware/api.errors');
 
 const app = express();
 const router = express.Router();
@@ -18,6 +19,7 @@ router.route("/book/:id/chapter").get(bookController.getChaptersByBook);
 
 app.use(express.json());
 app.use('/v2', router);
+app.use(errorHandler)
 
 describe('book controller', () => {
 

--- a/backend/controllers/chapter.api.js
+++ b/backend/controllers/chapter.api.js
@@ -1,10 +1,8 @@
 const Chapter = require("./../models/chapter.model");
 const config = require("./../helpers/config");
 
-const { errorResponse, HttpCode } = require('../helpers/constants');
-
 module.exports = {
-  getChapters: async (req, res) => {
+  getChapters: async (req, res, next) => {
     const options = await config.getOptions(req);
 
     try {
@@ -17,10 +15,10 @@ module.exports = {
       });
       return res.json(chapter);
     } catch (err) {
-      return res.status(HttpCode.SERVER_ERROR).send(errorResponse);
+      return next(err);
     }
   },
-  getChapter: async (req, res) => {
+  getChapter: async (req, res, next) => {
     const options = await config.getOptions(req);
     try {
       const id = req.params.id;
@@ -33,7 +31,7 @@ module.exports = {
       });
       return res.json(chapter);
     } catch (err) {
-      return res.status(HttpCode.SERVER_ERROR).send(errorResponse);
+      return next(err);
     }
   }
 }

--- a/backend/controllers/chapter.api.spec.js
+++ b/backend/controllers/chapter.api.spec.js
@@ -6,6 +6,7 @@ const { HttpCode } = require('../helpers/constants');
 
 const chapterModel = require('../models/chapter.model');
 const chapterController = require('./chapter.api');
+const errorHandler = require('../middleware/api.errors');
 
 const app = express();
 const router = express.Router();
@@ -15,6 +16,7 @@ router.route("/chapter/:id").get(chapterController.getChapter);
 
 app.use(express.json());
 app.use('/v2', router);
+app.use(errorHandler)
 
 describe('chapter controller', () => {
 

--- a/backend/controllers/character.api.js
+++ b/backend/controllers/character.api.js
@@ -4,8 +4,6 @@ const config = require("./../helpers/config");
 
 const mongoose = require("mongoose");
 
-const { errorResponse, HttpCode } = require('../helpers/constants');
-
 module.exports = {
   getCharacters: async (req, res, next) => {
     try {
@@ -13,7 +11,7 @@ module.exports = {
       const characters = await Character.paginate(options.filter, options);
       return res.json(characters);
     } catch (err) {
-      return res.status(HttpCode.SERVER_ERROR).send(errorResponse);
+      return next(err);
     }
   },
   getCharacter: async (req, res, next) => {
@@ -23,7 +21,7 @@ module.exports = {
       const character = await Character.paginate({ _id: id }, options);
       return res.json(character);
     } catch (err) {
-      return res.status(HttpCode.SERVER_ERROR).send(errorResponse);
+      return next(err);
     }
   },
   getQuoteByCharacter: async (req, res, next) => {
@@ -38,7 +36,7 @@ module.exports = {
         });
       return res.json(quotes);
     } catch (err) {
-      return res.status(HttpCode.SERVER_ERROR).send(errorResponse);
+      return next(err);
     }
   }
 };

--- a/backend/controllers/character.api.spec.js
+++ b/backend/controllers/character.api.spec.js
@@ -7,6 +7,7 @@ const { HttpCode } = require('../helpers/constants');
 const quoteModel = require('../models/quote.model');
 const characterModel = require('../models/character.model');
 const characterController = require('./character.api');
+const errorHandler = require('../middleware/api.errors');
 
 const app = express();
 const router = express.Router();
@@ -17,6 +18,7 @@ router.route("/character/:id/quote").get(characterController.getQuoteByCharacter
 
 app.use(express.json());
 app.use('/v2', router);
+app.use(errorHandler)
 
 describe('character controller', () => {
 

--- a/backend/controllers/movie.api.js
+++ b/backend/controllers/movie.api.js
@@ -4,17 +4,15 @@ const config = require("./../helpers/config");
 
 const mongoose = require("mongoose");
 
-const { errorResponse, HttpCode } = require('../helpers/constants');
-
 module.exports = {
-  getMovie: async (req, res,) => {
+  getMovie: async (req, res, next) => {
     try {
       const options = await config.getOptions(req);
       const id = req.params.id;
       const movie = await Movie.paginate({ _id: id }, options);
       return res.json(movie);
     } catch (err) {
-      return res.status(HttpCode.SERVER_ERROR).send(errorResponse);
+      return next(err);
     }
   },
   getMovies: async (req, res, next) => {
@@ -23,7 +21,7 @@ module.exports = {
       const movies = await Movie.paginate(options.filter, options);
       return res.json(movies);
     } catch (err) {
-      return res.status(HttpCode.SERVER_ERROR).send(errorResponse);
+      return next(err);
     }
   },
   getQuoteByMovie: async (req, res, next) => {
@@ -43,7 +41,7 @@ module.exports = {
       );
       return res.json(quotes);
     } catch (err) {
-      return res.status(HttpCode.SERVER_ERROR).send(errorResponse);
+      return next(err);
     }
   }
 };

--- a/backend/controllers/movie.api.spec.js
+++ b/backend/controllers/movie.api.spec.js
@@ -7,6 +7,7 @@ const movieModel = require('../models/movie.model');
 const movieController = require('./movie.api');
 
 const { HttpCode } = require('../helpers/constants');
+const errorHandler = require('../middleware/api.errors');
 
 const app = express();
 const router = express.Router();
@@ -17,6 +18,7 @@ router.route("/movie/:id/quote").get(movieController.getQuoteByMovie);
 
 app.use(express.json());
 app.use('/v2', router);
+app.use(errorHandler)
 
 describe('movie controller', () => {
 

--- a/backend/controllers/quote.api.js
+++ b/backend/controllers/quote.api.js
@@ -1,10 +1,8 @@
 const Quote = require("./../models/quote.model");
 const config = require("./../helpers/config");
 
-const { errorResponse, HttpCode } = require('../helpers/constants');
-
 module.exports = {
-  getQuotes: async (req, res) => {
+  getQuotes: async (req, res, next) => {
     try {
       const options = await config.getOptions(req);
       const quote = await Quote.paginate(
@@ -20,7 +18,7 @@ module.exports = {
       );
       return res.json(quote);
     } catch (err) {
-      return res.status(HttpCode.SERVER_ERROR).send(errorResponse);
+      return next(err);
     }
   },
   getQuote: async (req, res, next) => {
@@ -39,7 +37,7 @@ module.exports = {
         });
       return res.json(quote);
     } catch (err) {
-      return res.status(HttpCode.SERVER_ERROR).send(errorResponse);
+      return next(err);
     }
   }
 };

--- a/backend/controllers/quote.api.spec.js
+++ b/backend/controllers/quote.api.spec.js
@@ -6,6 +6,7 @@ const { HttpCode } = require('../helpers/constants');
 
 const quoteModel = require('../models/quote.model');
 const quoteController = require('./quote.api');
+const errorHandler = require('../middleware/api.errors');
 
 const app = express();
 const router = express.Router();
@@ -15,6 +16,7 @@ router.route("/quote/:id").get(quoteController.getQuote);
 
 app.use(express.json());
 app.use('/v2', router);
+app.use(errorHandler)
 
 describe('quote controller', () => {
 

--- a/backend/helpers/constants.js
+++ b/backend/helpers/constants.js
@@ -3,9 +3,15 @@ const errorResponse = {
     message: "Something went wrong."
 };
 
+const notFoundResponse = {
+    success: false,
+    message: "Not found."
+};
+
 const HttpCode = Object.freeze({
     OK: 200,
+    NOT_FOUND: 404,
     SERVER_ERROR: 500
 });
 
-module.exports = { errorResponse, HttpCode };
+module.exports = { errorResponse, notFoundResponse, HttpCode };

--- a/backend/middleware/api.errors.js
+++ b/backend/middleware/api.errors.js
@@ -1,0 +1,7 @@
+const { HttpCode, errorResponse } = require("../helpers/constants")
+
+const errorHandler = (err, req, res, next) => {
+    res.status(HttpCode.SERVER_ERROR).send(errorResponse)
+}
+
+module.exports = errorHandler

--- a/backend/middleware/api.limiter.js
+++ b/backend/middleware/api.limiter.js
@@ -2,6 +2,10 @@ const rateLimit = require("express-rate-limit");
 const apiLimiter = rateLimit({
     windowMs: 10 * 60 * 1000, // 15 minutes
     max: 100,
+    message: {
+        success: false,
+        message: "Too many requests, please try again later."
+    }
     // skip limiter for special tokens (e.g. hackathons)
     // skip: function (req, res) {
     //   const token = req.header('authorization')?.split(' ')[1];

--- a/backend/middleware/api.limiter.js
+++ b/backend/middleware/api.limiter.js
@@ -1,6 +1,6 @@
 const rateLimit = require("express-rate-limit");
 const apiLimiter = rateLimit({
-    windowMs: 10 * 60 * 1000, // 15 minutes
+    windowMs: 10 * 60 * 1000, // 10 minutes
     max: 100,
     message: {
         success: false,

--- a/backend/middleware/api.limiter.spec.js
+++ b/backend/middleware/api.limiter.spec.js
@@ -25,6 +25,9 @@ describe('api  limiter', () => {
             response = await request(app).get('/v2/book/');
         }
         expect(response.statusCode).toEqual(429);
-        expect(response.text).toEqual('Too many requests, please try again later.');
+        expect(response.body).toEqual({
+            success: false,
+            message: "Too many requests, please try again later."
+        });
     });
 });

--- a/backend/middleware/auth.limiter.spec.js
+++ b/backend/middleware/auth.limiter.spec.js
@@ -8,7 +8,14 @@ const authLimiter = require('../middleware/auth.limiter');
 const rateLimit = 1;
 const hourWindow = 60 * 60 * 1000;
 
-router.route('/register').post([authLimiter({ windowMs: hourWindow, max: rateLimit }), (req, res) => res.sendStatus(200)]);
+router.route('/register').post([authLimiter({
+    windowMs: hourWindow,
+    max: rateLimit,
+    message: {
+        success: false,
+        message: "Too many requests, please try again later."
+    }
+}), (req, res) => res.sendStatus(200)]);
 
 app.use(express.json());
 app.use('/auth', router);
@@ -28,6 +35,9 @@ describe('auth limiter', () => {
             response = await request(app).post('/auth/register/').send(requestBody);
         }
         expect(response.statusCode).toEqual(429);
-        expect(response.text).toEqual('Too many requests, please try again later.');
+        expect(response.body).toEqual({
+            success: false,
+            message: "Too many requests, please try again later."
+        });
     });
 });

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -7,6 +7,7 @@ var quoteController = require("./../controllers/quote.api");
 
 var router = express.Router();
 var passportHelpers = require("./../helpers/passport");
+const { notFoundResponse, HttpCode } = require("../helpers/constants");
 
 router.route("/book").get(bookController.getBooks);
 router.route("/book/:id").get(bookController.getBook);
@@ -35,10 +36,10 @@ router
   .route("/character/:id")
   .get([passportHelpers.authenticate, characterController.getCharacter]);
 
-  router
+router
   .route("/character/:id/quote")
   .get([passportHelpers.authenticate, characterController.getQuoteByCharacter]);
-  
+
 
 router
   .route("/quote")
@@ -48,8 +49,7 @@ router
   .get([passportHelpers.authenticate, quoteController.getQuote]);
 
 router.route("*").get(async function (req, res) {
-    return res.status(404).send("Endpoint does not exist.");
+  return res.status(HttpCode.NOT_FOUND).send(notFoundResponse);
 });
-
 
 module.exports = router;

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -7,7 +7,8 @@ var quoteController = require("./../controllers/quote.api");
 
 var router = express.Router();
 var passportHelpers = require("./../helpers/passport");
-const { notFoundResponse, HttpCode } = require("../helpers/constants");
+const { errorResponse, notFoundResponse, HttpCode } = require("../helpers/constants");
+const errorHandler = require("../middleware/api.errors");
 
 router.route("/book").get(bookController.getBooks);
 router.route("/book/:id").get(bookController.getBook);
@@ -51,5 +52,9 @@ router
 router.route("*").get(async function (req, res) {
   return res.status(HttpCode.NOT_FOUND).send(notFoundResponse);
 });
+
+// global error handler. this should always be the last .use
+// and after all routes
+router.use(errorHandler)
 
 module.exports = router;

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -5,11 +5,12 @@ var passportHelpers = require("./../helpers/passport");
 var router = express.Router();
 
 const authLimiter = require("../middleware/auth.limiter");
+const { notFoundResponse } = require("../helpers/constants");
 
 router.route("/login").post([passportHelpers.login, authController.login]);
 //allow only 5 calls per hour to this endpoint
 router.route("/register").post([authLimiter({ windowMs: 60 * 60 * 1000, max: 5 }), authController.register]);
 router.route("*").get(async function (req, res) {
-  return res.status(404).send("Endpoint does not exist.");
+  return res.status(404).send(notFoundResponse);
 });
 module.exports = router;

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -9,7 +9,14 @@ const { notFoundResponse } = require("../helpers/constants");
 
 router.route("/login").post([passportHelpers.login, authController.login]);
 //allow only 5 calls per hour to this endpoint
-router.route("/register").post([authLimiter({ windowMs: 60 * 60 * 1000, max: 5 }), authController.register]);
+router.route("/register").post([authLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  message: {
+    success: false,
+    message: "Too many requests, please try again later."
+  }
+}), authController.register]);
 router.route("*").get(async function (req, res) {
   return res.status(404).send(notFoundResponse);
 });


### PR DESCRIPTION
These 3 commits attempt to make the API more consistent in returning JSON errors with non-2xx HTTP error codes.

- When requesting an unknown URL or exceeding rate limits the response is returned as plaintext instead of JSON: https://the-one-api.dev/v2/notreal
  - Both should be addressed by the 1st and 3rd commits
- Error handling in the Book endpoints was not returning a status code so 200 comes back: https://the-one-api.dev/v2/book/123
  - Instead of inserting the 500 status code like the other endpoints currently do I centralized the entire error handling to the final express error handler so if the error message ever needs to change it can happen in one place.
    - [Express docs](https://expressjs.com/en/guide/error-handling.html) say `Starting with Express 5, route handlers and middleware that return a Promise will call next(value) automatically when they reject or throw an error`.  If this repo is ever ever upgraded to Express 5 (currently on 4.17) or later these new try blocks can be entirely removed, the next() calls will be automatic.

The 4th commit updates a code comment to reflect the latest code.